### PR TITLE
Adição de campo extra ao disparar evento de atualizar campo de sincronização após o disparo de uma excessão. 

### DIFF
--- a/modulos/Academico/Listeners/DeleteGrupoAlunoListener.php
+++ b/modulos/Academico/Listeners/DeleteGrupoAlunoListener.php
@@ -70,7 +70,7 @@ class DeleteGrupoAlunoListener
                 throw $exception;
             }
 
-            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction()));
+            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction(), null, $event->getExtra()));
         } finally {
             return true;
         }

--- a/modulos/Academico/Listeners/DeleteGrupoListener.php
+++ b/modulos/Academico/Listeners/DeleteGrupoListener.php
@@ -68,7 +68,7 @@ class DeleteGrupoListener
                 throw $exception;
             }
 
-            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction()));
+            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction(), null, $event->getExtra()));
         } finally {
             return true;
         }

--- a/modulos/Academico/Listeners/DeleteOfertaDisciplinaListener.php
+++ b/modulos/Academico/Listeners/DeleteOfertaDisciplinaListener.php
@@ -63,7 +63,7 @@ class DeleteOfertaDisciplinaListener
                 throw $exception;
             }
 
-            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction()));
+            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction(), null, $event->getExtra()));
         } finally {
             return true;
         }

--- a/modulos/Academico/Listeners/UpdateGrupoAlunoListener.php
+++ b/modulos/Academico/Listeners/UpdateGrupoAlunoListener.php
@@ -73,7 +73,7 @@ class UpdateGrupoAlunoListener
                 throw $exception;
             }
 
-            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction()));
+            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction(), null, $event->getExtra()));
         } finally {
             return true;
         }

--- a/modulos/Geral/Listeners/UpdatePessoaListener.php
+++ b/modulos/Geral/Listeners/UpdatePessoaListener.php
@@ -85,7 +85,7 @@ class UpdatePessoaListener
                 throw $exception;
             }
 
-            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction()));
+            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction(), null, $event->getExtra()));
         }
     }
 }

--- a/modulos/Integracao/Listeners/TurmaRemovidaListener.php
+++ b/modulos/Integracao/Listeners/TurmaRemovidaListener.php
@@ -80,7 +80,7 @@ class TurmaRemovidaListener
                 throw $exception;
             }
 
-            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction()));
+            event(new UpdateSincronizacaoEvent($event->getData(), 3, get_class($exception), $event->getAction(), null, $event->getExtra()));
         } finally {
             return true;
         }


### PR DESCRIPTION
Em alguns caso é necessário passar o parâmetro "extra" ao disparar um evento. Nesses casos, quando alguma excessão é disparada, o parâmetro não estava sendo passado ao chamar a função de atualizar a tabela de sincronização, este PR resolve conserta esse problema.