### PR TITLE
Matrícula  em Lote para disciplina

### DIFF
--- a/Harpia/Event/Contracts/SincronizacaoLoteInterface.php
+++ b/Harpia/Event/Contracts/SincronizacaoLoteInterface.php
@@ -12,7 +12,9 @@ use Illuminate\Support\Collection;
  */
 interface SincronizacaoLoteInterface
 {
-    public function getItens(): Collection;
+    public function getItems(): Collection;
 
     public function getBaseClass(): string;
+
+    public function getItemsAsEvents(): Collection;
 }

--- a/Harpia/Event/Contracts/SincronizacaoLoteInterface.php
+++ b/Harpia/Event/Contracts/SincronizacaoLoteInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Harpia\Event\Contracts;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Interface SincronizacaoLoteInterface
+ *
+ * @package Harpia\Event\Contracts
+ */
+interface SincronizacaoLoteInterface
+{
+    public function getItens(): Collection;
+
+    public function getBaseClass(): string;
+}

--- a/Harpia/Event/SincronizacaoEvent.php
+++ b/Harpia/Event/SincronizacaoEvent.php
@@ -59,7 +59,7 @@ abstract class SincronizacaoEvent extends Event
      * Retorna o endpoint correspondente ao evento de sincronizacao
      * @return string
      */
-    final public function getEndpoint()
+    public function getEndpoint()
     {
         if (isset(self::ENDPOINTS[$this->entry->getTable()][$this->action])) {
             return self::ENDPOINTS[$this->entry->getTable()][$this->action];

--- a/Harpia/Event/SincronizacaoLoteEvent.php
+++ b/Harpia/Event/SincronizacaoLoteEvent.php
@@ -12,24 +12,35 @@ use Harpia\Event\Contracts\SincronizacaoLoteInterface;
  */
 abstract class SincronizacaoLoteEvent extends SincronizacaoEvent implements SincronizacaoLoteInterface
 {
-    protected $itens;
+    protected $items;
 
     protected $baseClass = "";
 
-    public function __construct(Collection $itens, string $action = "CREATE", $extra = null)
+    public function __construct(Collection $items, string $action = "CREATE", $extra = null)
     {
         $this->extra = $extra;
-        $this->itens = $itens;
+        $this->items = $items;
         $this->action = $action;
     }
 
-    public function getItens(): Collection
+    public function getItems(): Collection
     {
-        return $this->itens;
+        return $this->items;
     }
 
     public function getBaseClass(): string
     {
         return $this->baseClass;
+    }
+
+    public function getItemsAsEvents(): Collection
+    {
+        $events = collect([]);
+
+        foreach ($this->items as $item) {
+            $events->push(new $this->baseClass($item, $this->extra));
+        }
+
+        return $events;
     }
 }

--- a/Harpia/Event/SincronizacaoLoteEvent.php
+++ b/Harpia/Event/SincronizacaoLoteEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Harpia\Event;
+
+use Illuminate\Support\Collection;
+use Harpia\Event\Contracts\SincronizacaoLoteInterface;
+
+/**
+ * Classe base para eventos de sincronizacao em lote
+ *
+ * @package Harpia\Event
+ */
+abstract class SincronizacaoLoteEvent extends SincronizacaoEvent implements SincronizacaoLoteInterface
+{
+    protected $itens;
+
+    protected $baseClass = "";
+
+    public function __construct(Collection $itens, string $action = "CREATE", $extra = null)
+    {
+        $this->extra = $extra;
+        $this->itens = $itens;
+        $this->action = $action;
+    }
+
+    public function getItens(): Collection
+    {
+        return $this->itens;
+    }
+
+    public function getBaseClass(): string
+    {
+        return $this->baseClass;
+    }
+}

--- a/modulos/Academico/Events/CreateMatriculaDisciplinaLoteEvent.php
+++ b/modulos/Academico/Events/CreateMatriculaDisciplinaLoteEvent.php
@@ -28,4 +28,13 @@ class CreateMatriculaDisciplinaLoteEvent extends SincronizacaoLoteEvent
 
         parent::__construct($matriculas, $action, $extra);
     }
+
+    /**
+     * TODO review endpoint name
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return 'local_integracao_batch_enrol_student_discipline';
+    }
 }

--- a/modulos/Academico/Events/CreateMatriculaDisciplinaLoteEvent.php
+++ b/modulos/Academico/Events/CreateMatriculaDisciplinaLoteEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modulos\Academico\Events;
+
+use Illuminate\Support\Collection;
+use Harpia\Event\SincronizacaoLoteEvent;
+use Modulos\Academico\Models\MatriculaOfertaDisciplina;
+
+class CreateMatriculaDisciplinaLoteEvent extends SincronizacaoLoteEvent
+{
+    /**
+     * CreateMatriculaDisciplinaLoteEvent constructor.
+     *
+     * @param Collection $matriculas
+     * @param string $action
+     * @param null $extra
+     * @throws \Exception
+     */
+    public function __construct(Collection $matriculas, string $action = "CREATE", $extra = null)
+    {
+        $this->baseClass = CreateMatriculaDisciplinaEvent::class;
+
+        foreach ($matriculas as $matricula) {
+            if (!$matricula instanceof MatriculaOfertaDisciplina) {
+                throw new \Exception("Objeto não é instância de " . MatriculaOfertaDisciplina::class);
+            }
+        }
+
+        parent::__construct($matriculas, $action, $extra);
+    }
+}

--- a/modulos/Academico/Events/CreateMatriculaDisciplinaLoteEvent.php
+++ b/modulos/Academico/Events/CreateMatriculaDisciplinaLoteEvent.php
@@ -30,7 +30,6 @@ class CreateMatriculaDisciplinaLoteEvent extends SincronizacaoLoteEvent
     }
 
     /**
-     * TODO review endpoint name
      * @return string
      */
     public function getEndpoint()

--- a/modulos/Academico/Http/Controllers/Async/MatriculaOfertaDisciplina.php
+++ b/modulos/Academico/Http/Controllers/Async/MatriculaOfertaDisciplina.php
@@ -2,14 +2,15 @@
 
 namespace Modulos\Academico\Http\Controllers\Async;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use Modulos\Core\Http\Controller\BaseController;
 use Modulos\Academico\Events\CreateMatriculaDisciplinaEvent;
 use Modulos\Academico\Repositories\MatriculaCursoRepository;
+use Modulos\Academico\Events\CreateMatriculaDisciplinaLoteEvent;
 use Modulos\Academico\Repositories\MatriculaOfertaDisciplinaRepository;
-use Modulos\Core\Http\Controller\BaseController;
 
 class MatriculaOfertaDisciplina extends BaseController
 {
@@ -53,7 +54,7 @@ class MatriculaOfertaDisciplina extends BaseController
         DB::beginTransaction();
 
         try {
-            $matriculasCollection = [];
+            $matriculasCollection = collect([]);
 
             foreach ($matriculas as $matricula) {
                 $result = $this->matriculaOfertaDisciplinaRepository->createMatricula(['mat_id' => $matricula, 'ofd_id' => $ofertaId]);
@@ -75,9 +76,7 @@ class MatriculaOfertaDisciplina extends BaseController
 
             if ($turma->trm_integrada) {
                 if (!empty($matriculasCollection)) {
-                    foreach ($matriculasCollection as $obj) {
-                        event(new CreateMatriculaDisciplinaEvent($obj));
-                    }
+                    event(new CreateMatriculaDisciplinaLoteEvent($matriculasCollection));
                 }
             }
 

--- a/modulos/Academico/Listeners/CreateMatriculaDisciplinaLoteListener.php
+++ b/modulos/Academico/Listeners/CreateMatriculaDisciplinaLoteListener.php
@@ -2,7 +2,11 @@
 
 namespace Modulos\Academico\Listeners;
 
+use Moodle;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 use Modulos\Academico\Repositories\AlunoRepository;
+use Modulos\Integracao\Events\UpdateSincronizacaoEvent;
 use Modulos\Integracao\Repositories\AmbienteVirtualRepository;
 use Modulos\Academico\Events\CreateMatriculaDisciplinaLoteEvent;
 
@@ -14,13 +18,72 @@ class CreateMatriculaDisciplinaLoteListener
     public function __construct(
         AlunoRepository $alunoRepository,
         AmbienteVirtualRepository $ambienteVirtualRepository
-    ) {
+    )
+    {
         $this->alunoRepository = $alunoRepository;
         $this->ambienteVirtualRepository = $ambienteVirtualRepository;
     }
 
     public function handle(CreateMatriculaDisciplinaLoteEvent $event)
     {
-        // TODO implement
+        try {
+            $param = [];
+
+            // Reunir os dados para envio em lote
+            foreach ($event->getItems() as $matriculaOfertaDisciplina) {
+                $enrol = [];
+
+                $aluno = $this->alunoRepository->find($matriculaOfertaDisciplina->matriculaCurso->mat_alu_id);
+
+                $enrol['mof_id'] = $matriculaOfertaDisciplina->mof_id;
+                $enrol['pes_id'] = $aluno->alu_pes_id;
+                $enrol['ofd_id'] = $matriculaOfertaDisciplina->mof_ofd_id;
+
+                $param['data']['enrol'][] = $enrol;
+                unset($enrol);
+            }
+
+            $idTurma = $event->getItems()->random()->matriculaCurso->mat_trm_id;
+            $ambiente = $this->ambienteVirtualRepository->getAmbienteByTurma($idTurma);
+
+            if (!$ambiente) {
+                return;
+            }
+
+            $ambServico = $ambiente->integracao();
+
+            // url do ambiente
+            $param['url'] = $ambiente->amb_url;
+            $param['token'] = $ambServico->asr_token;
+            $param['functionname'] = $event->getEndpoint();
+            $param['action'] = 'CREATE';
+
+            // TODO verificar formato de resposta do ambiente
+            // Processar resposta
+            $response = Moodle::send($param);
+
+            $status = 3;
+
+            if (array_key_exists('status', $response)) {
+                if ($response['status'] == 'success') {
+                    $status = 2;
+                }
+            }
+
+            // Log individual de cada item
+            foreach ($event->getItems() as $item) {
+                event(new UpdateSincronizacaoEvent($item, $status, $response['message']));
+            }
+        } catch (ConnectException | ClientException | \Exception $exception) {
+
+            if (env('app.debug')) {
+                throw $exception;
+            }
+
+            foreach ($event->getItems() as $item) {
+                event(new UpdateSincronizacaoEvent($item, 3, get_class($exception), $event->getAction()));
+            }
+
+        }
     }
 }

--- a/modulos/Academico/Listeners/CreateMatriculaDisciplinaLoteListener.php
+++ b/modulos/Academico/Listeners/CreateMatriculaDisciplinaLoteListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Modulos\Academico\Listeners;
+
+use Modulos\Academico\Repositories\AlunoRepository;
+use Modulos\Integracao\Repositories\AmbienteVirtualRepository;
+use Modulos\Academico\Events\CreateMatriculaDisciplinaLoteEvent;
+
+class CreateMatriculaDisciplinaLoteListener
+{
+    protected $alunoRepository;
+    protected $ambienteVirtualRepository;
+
+    public function __construct(
+        AlunoRepository $alunoRepository,
+        AmbienteVirtualRepository $ambienteVirtualRepository
+    ) {
+        $this->alunoRepository = $alunoRepository;
+        $this->ambienteVirtualRepository = $ambienteVirtualRepository;
+    }
+
+    public function handle(CreateMatriculaDisciplinaLoteEvent $event)
+    {
+        // TODO implement
+    }
+}

--- a/modulos/Academico/events.php
+++ b/modulos/Academico/events.php
@@ -33,6 +33,11 @@ return [
         'Modulos\Academico\Listeners\CreateMatriculaDisciplinaListener',
     ],
 
+    'Modulos\Academico\Events\CreateMatriculaDisciplinaLoteEvent' => [
+        'Modulos\Integracao\Listeners\SincronizacaoListener' => 10,
+        'Modulos\Academico\Listeners\CreateMatriculaDisciplinaLoteListener',
+    ],
+
     'Modulos\Academico\Events\CreateVinculoTutorEvent' => [
         'Modulos\Integracao\Listeners\SincronizacaoListener' => 10,
         'Modulos\Academico\Listeners\CreateVinculoTutorListener',

--- a/modulos/Academico/tests/Listeners/CreateMatriculaDisciplinaLoteListenerTest.php
+++ b/modulos/Academico/tests/Listeners/CreateMatriculaDisciplinaLoteListenerTest.php
@@ -1,0 +1,246 @@
+<?php
+
+use GuzzleHttp\Client;
+use Tests\ModulosTestCase;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Harpia\Moodle\Facades\Moodle;
+use GuzzleHttp\Handler\MockHandler;
+use Modulos\Academico\Events\CreateGrupoEvent;
+use Modulos\Integracao\Events\TurmaMapeadaEvent;
+use Modulos\Academico\Events\CreateMatriculaTurmaEvent;
+use Modulos\Academico\Events\CreateMatriculaDisciplinaEvent;
+
+/**
+ * Class CreateMatriculaDisciplinaListenerTest
+ * @group Listeners
+ */
+class CreateMatriculaDisciplinaLoteListenerTest extends ModulosTestCase
+{
+    protected $ambiente;
+    protected $matriculaCurso;
+    protected $matriculaDisciplina;
+    protected $sincronizacaoRepository;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->sincronizacaoRepository = $this->app->make(\Modulos\Integracao\Repositories\SincronizacaoRepository::class);
+
+        Modulos\Integracao\Models\Servico::truncate();
+
+        $this->createAmbiente();
+        $this->createIntegracao();
+        $this->createMonitor();
+        $this->mockUpDatabase();
+    }
+
+    /**
+     * Cria um ambiente de testes a partir das variaveis de ambiente
+     *
+     * @return void
+     */
+    private function createAmbiente()
+    {
+        $moodle = [
+            'amb_nome' => 'Moodle',
+            'amb_versao' => '3.2+',
+            'amb_url' => "http://localhost:8080"
+        ];
+
+        $this->ambiente = factory(Modulos\Integracao\Models\AmbienteVirtual::class)->create($moodle);
+    }
+
+    /**
+     * Cria o registro do plugin de integracao a partir das variaveis de ambiente
+     *
+     * @return void
+     */
+    private function createIntegracao()
+    {
+        $servico = factory(Modulos\Integracao\Models\Servico::class)->create([
+            'ser_id' => 2,
+            'ser_nome' => "Integração",
+            'ser_slug' => "local_integracao"
+        ]);
+
+        $ambienteServico = factory(\Modulos\Integracao\Models\AmbienteServico::class)->create([
+            'asr_amb_id' => $this->ambiente->amb_id,
+            'asr_ser_id' => $servico->ser_id,
+            'asr_token' => "aksjhdeuig2768125sahsjhdvjahsy"
+        ]);
+    }
+
+    /**
+     * Cria o registro do plugin de monitoramento a partir das variaveis de ambiente
+     *
+     * @return void
+     */
+    private function createMonitor()
+    {
+        $servico = factory(Modulos\Integracao\Models\Servico::class)->create([
+            'ser_nome' => "Monitor",
+            'ser_slug' => "get_tutor_online_time"
+        ]);
+
+        $ambienteServico = factory(\Modulos\Integracao\Models\AmbienteServico::class)->create([
+            'asr_amb_id' => $this->ambiente->amb_id,
+            'asr_ser_id' => $servico->ser_id,
+            'asr_token' => "abcdefgh12345"
+        ]);
+    }
+
+    private function mockUpDatabaseLote(int $qtdeMatriculas = 20)
+    {
+        // Cria a turma
+        $data = [
+            'trm_id' => random_int(50, 100),
+            'trm_ofc_id' => factory(Modulos\Academico\Models\OfertaCurso::class)->create()->ofc_id,
+            'trm_per_id' => factory(Modulos\Academico\Models\PeriodoLetivo::class)->create()->per_id,
+            'trm_nome' => "Turma de Teste",
+            'trm_integrada' => 1,
+            'trm_qtd_vagas' => 50
+        ];
+
+        $this->turma = factory(Modulos\Academico\Models\Turma::class)->create($data);
+
+        // Vincular com o ambiente
+        factory(\Modulos\Integracao\Models\AmbienteTurma::class)->create([
+            'atr_trm_id' => $this->turma->trm_id,
+            'atr_amb_id' => $this->ambiente->amb_id
+        ]);
+
+        // Mapeia a turma
+        $sincronizacaoListener = $this->app->make(\Modulos\Integracao\Listeners\SincronizacaoListener::class);
+        $turmaMapeadaListener = $this->app->make(\Modulos\Integracao\Listeners\TurmaMapeadaListener::class);
+        $createGroupListener = $this->app->make(\Modulos\Academico\Listeners\CreateGrupoListener::class);
+        $createMatriculaTurmaListener = $this->app->make(\Modulos\Academico\Listeners\CreateMatriculaTurmaListener::class);
+
+        // Eventos de turma
+        $turmaMapeadaEvent = new TurmaMapeadaEvent($this->turma);
+
+        $sincronizacaoListener->handle($turmaMapeadaEvent);
+        $turmaMapeadaListener->handle($turmaMapeadaEvent);
+
+        // Cria o grupo
+        $grupo = factory(\Modulos\Academico\Models\Grupo::class)->create([
+            'grp_trm_id' => $this->turma->trm_id,
+            'grp_pol_id' => factory(Modulos\Academico\Models\Polo::class)->create()->pol_id,
+            'grp_nome' => "Group A"
+        ]);
+
+        // Eventos de grupo
+        $createGroupEvent = new CreateGrupoEvent($grupo);
+
+        $sincronizacaoListener->handle($createGroupEvent);
+        $createGroupListener->handle($createGroupEvent);
+
+        // Cria a matricula no curso
+        $matriculaCurso = factory(\Modulos\Academico\Models\Matricula::class)->create([
+            'mat_trm_id' => $this->turma->trm_id,
+            'mat_grp_id' => $grupo->grp_id,
+        ]);
+
+        $createMatriculaTurmaEvent = new CreateMatriculaTurmaEvent($matriculaCurso);
+
+        // Eventos de Matricula no curso
+        $sincronizacaoListener->handle($createMatriculaTurmaEvent);
+        $createMatriculaTurmaListener->handle($createMatriculaTurmaEvent);
+
+        // Matricula disciplina
+        $matriculasDisciplinas = collect([]);
+
+        for ($i = 0; $i < $qtdeMatriculas; $i++) {
+            $matriculasDisciplinas[] = factory(\Modulos\Academico\Models\MatriculaOfertaDisciplina::class)->create([
+                'mof_mat_id' => $matriculaCurso->mat_id,
+            ]);
+        }
+
+        return $matriculasDisciplinas;
+    }
+
+    public function testHandleWithSuccess()
+    {
+        // Mock do servidor
+        $container = [];
+        $history = Middleware::history($container);
+
+        // Mock de respostas do servidor // TODO Check with server implementation
+        $mock = new MockHandler([
+            new Response(200, ['content-type' => 'application/text'], json_encode([
+                "id" => random_int(1, 10),
+                "status" => "success",
+                "message" => "Aluno matriculado com sucesso"
+            ])),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+        $client = new Client(['handler' => $handler]);
+
+        // Seta cliente de testes
+        Moodle::setClient($client);
+
+        $sincronizacaoListener = $this->app->make(\Modulos\Integracao\Listeners\SincronizacaoListener::class);
+        $createMatriculaDisciplinaListener = $this->app->make(\Modulos\Academico\Listeners\CreateMatriculaDisciplinaListener::class);
+
+        $this->assertEquals(3, $this->sincronizacaoRepository->count());
+
+        $createMatriculaDisciplinaEvent = new CreateMatriculaDisciplinaEvent($this->matriculaDisciplina);
+        $sincronizacaoListener->handle($createMatriculaDisciplinaEvent);
+
+        $this->assertDatabaseHas('int_sync_moodle', [
+            'sym_table' => $createMatriculaDisciplinaEvent->getData()->getTable(),
+            'sym_table_id' => $createMatriculaDisciplinaEvent->getData()->getKey(),
+            'sym_action' => $createMatriculaDisciplinaEvent->getAction(),
+            'sym_status' => 1,
+            'sym_mensagem' => null,
+            'sym_data_envio' => null,
+            'sym_extra' => $createMatriculaDisciplinaEvent->getExtra()
+        ]);
+
+        $this->expectsEvents(\Modulos\Integracao\Events\UpdateSincronizacaoEvent::class);
+        $createMatriculaDisciplinaListener->handle($createMatriculaDisciplinaEvent);
+
+        $this->assertEquals(4, $this->sincronizacaoRepository->count());
+    }
+
+    public function testHandleWithFail()
+    {
+        // Mock do servidor
+        $container = [];
+        $history = Middleware::history($container);
+
+        // A falta do Mock de response causa o disparo de uma excecao no Listener
+        $handler = HandlerStack::create();
+        $handler->push($history);
+        $client = new Client(['handler' => $handler]);
+
+        // Seta cliente de testes
+        Moodle::setClient($client);
+
+        $sincronizacaoListener = $this->app->make(\Modulos\Integracao\Listeners\SincronizacaoListener::class);
+        $createMatriculaDisciplinaListener = $this->app->make(\Modulos\Academico\Listeners\CreateMatriculaDisciplinaListener::class);
+
+        $this->assertEquals(3, $this->sincronizacaoRepository->count());
+
+        $createMatriculaDisciplinaEvent = new CreateMatriculaDisciplinaEvent($this->matriculaDisciplina);
+        $sincronizacaoListener->handle($createMatriculaDisciplinaEvent);
+
+        $this->assertDatabaseHas('int_sync_moodle', [
+            'sym_table' => $createMatriculaDisciplinaEvent->getData()->getTable(),
+            'sym_table_id' => $createMatriculaDisciplinaEvent->getData()->getKey(),
+            'sym_action' => $createMatriculaDisciplinaEvent->getAction(),
+            'sym_status' => 1,
+            'sym_mensagem' => null,
+            'sym_data_envio' => null,
+            'sym_extra' => $createMatriculaDisciplinaEvent->getExtra()
+        ]);
+
+        $this->expectsEvents(\Modulos\Integracao\Events\UpdateSincronizacaoEvent::class);
+        $createMatriculaDisciplinaListener->handle($createMatriculaDisciplinaEvent);
+
+        $this->assertEquals(4, $this->sincronizacaoRepository->count());
+    }
+}

--- a/modulos/Academico/tests/Listeners/CreateMatriculaDisciplinaLoteListenerTest.php
+++ b/modulos/Academico/tests/Listeners/CreateMatriculaDisciplinaLoteListenerTest.php
@@ -9,12 +9,11 @@ use Harpia\Moodle\Facades\Moodle;
 use GuzzleHttp\Handler\MockHandler;
 use Modulos\Academico\Events\CreateGrupoEvent;
 use Modulos\Integracao\Events\TurmaMapeadaEvent;
-use Modulos\Academico\Events\CreateMatriculaTurmaEvent;
 use Modulos\Academico\Events\CreateMatriculaDisciplinaEvent;
 use Modulos\Academico\Events\CreateMatriculaDisciplinaLoteEvent;
 
 /**
- * Class CreateMatriculaDisciplinaListenerTest
+ * Class CreateMatriculaDisciplinaLoteListenerTest
  * @group Listeners
  */
 class CreateMatriculaDisciplinaLoteListenerTest extends ModulosTestCase
@@ -160,7 +159,6 @@ class CreateMatriculaDisciplinaLoteListenerTest extends ModulosTestCase
         $container = [];
         $history = Middleware::history($container);
 
-        // TODO Check with server implementation
         // Mock de respostas do servidor
         $mock = new MockHandler([
             new Response(200, ['content-type' => 'application/text'], json_encode([

--- a/modulos/Integracao/Listeners/SincronizacaoListener.php
+++ b/modulos/Integracao/Listeners/SincronizacaoListener.php
@@ -31,6 +31,8 @@ class SincronizacaoListener
 
                     unset($itemEvent);
                 }
+
+                return true; // Passa para os demais listeners
             }
 
             if ($event->isFirstAttempt()) {

--- a/modulos/Integracao/Listeners/SincronizacaoListener.php
+++ b/modulos/Integracao/Listeners/SincronizacaoListener.php
@@ -23,9 +23,7 @@ class SincronizacaoListener
                 $class = $event->getBaseClass();
 
                 // Salva cada item de uma migracao em lote como uma migracao individual na tabela de sincronizacao
-                foreach ($event->getItens() as $item) {
-                    $itemEvent = new $class($item);
-
+                foreach ($event->getItemsAsEvents() as $itemEvent) {
                     $data = $this->getSyncData($itemEvent);
                     $this->sincronizacaoRepository->create($data);
 
@@ -52,7 +50,7 @@ class SincronizacaoListener
         }
     }
 
-    protected function getSyncData(SincronizacaoEvent $event) : array
+    protected function getSyncData(SincronizacaoEvent $event): array
     {
         $entry = $event->getData();
 

--- a/modulos/Integracao/Listeners/SincronizacaoListener.php
+++ b/modulos/Integracao/Listeners/SincronizacaoListener.php
@@ -2,6 +2,7 @@
 
 namespace Modulos\Integracao\Listeners;
 
+use Harpia\Event\Contracts\SincronizacaoLoteInterface;
 use Harpia\Event\SincronizacaoEvent;
 use Modulos\Integracao\Repositories\SincronizacaoRepository;
 
@@ -17,19 +18,23 @@ class SincronizacaoListener
     public function handle(SincronizacaoEvent $event)
     {
         try {
+            // Migracao em lote
+            if ($event instanceof SincronizacaoLoteInterface) {
+                $class = $event->getBaseClass();
+
+                // Salva cada item de uma migracao em lote como uma migracao individual na tabela de sincronizacao
+                foreach ($event->getItens() as $item) {
+                    $itemEvent = new $class($item);
+
+                    $data = $this->getSyncData($itemEvent);
+                    $this->sincronizacaoRepository->create($data);
+
+                    unset($itemEvent);
+                }
+            }
+
             if ($event->isFirstAttempt()) {
-                $entry = $event->getData();
-
-                $data = [
-                    'sym_table' => $entry->getTable(),
-                    'sym_table_id' => $entry->getKey(),
-                    'sym_action' => $event->getAction(),
-                    'sym_status' => 1,
-                    'sym_mensagem' => null,
-                    'sym_data_envio' => null,
-                    'sym_extra' => $event->getExtra()
-                ];
-
+                $data = $this->getSyncData($event);
                 $this->sincronizacaoRepository->create($data);
             }
             // @codeCoverageIgnoreStart
@@ -43,5 +48,20 @@ class SincronizacaoListener
             // Mantem a propagacao do evento
             return true;
         }
+    }
+
+    protected function getSyncData(SincronizacaoEvent $event) : array
+    {
+        $entry = $event->getData();
+
+        return [
+            'sym_table' => $entry->getTable(),
+            'sym_table_id' => $entry->getKey(),
+            'sym_action' => $event->getAction(),
+            'sym_status' => 1,
+            'sym_mensagem' => null,
+            'sym_data_envio' => null,
+            'sym_extra' => $event->getExtra()
+        ];
     }
 }

--- a/modulos/Integracao/tests/Listeners/SincronizacaoListenerTest.php
+++ b/modulos/Integracao/tests/Listeners/SincronizacaoListenerTest.php
@@ -217,7 +217,7 @@ class SincronizacaoListenerTest extends ModulosTestCase
 
         // Cria um evento de matricula com alguma das matriculas passadas.
         // O objetivo eh checar se ha um log individual daquele registro na tabela de sincronizacao
-        $matriculaDisciplinaEvent = new CreateMatriculaDisciplinaEvent($matriculaDisciplinaLoteEvent->getItens()->random());
+        $matriculaDisciplinaEvent = new CreateMatriculaDisciplinaEvent($matriculaDisciplinaLoteEvent->getItems()->random());
 
         $this->assertDatabaseHas('int_sync_moodle', [
             'sym_table' => $matriculaDisciplinaEvent->getData()->getTable(),
@@ -228,6 +228,5 @@ class SincronizacaoListenerTest extends ModulosTestCase
             'sym_data_envio' => null,
             'sym_extra' => $matriculaDisciplinaEvent->getExtra()
         ]);
-
     }
 }

--- a/modulos/Integracao/tests/Listeners/SincronizacaoListenerTest.php
+++ b/modulos/Integracao/tests/Listeners/SincronizacaoListenerTest.php
@@ -2,7 +2,11 @@
 
 use Tests\ModulosTestCase;
 use Illuminate\Support\Facades\Schema;
+use Modulos\Academico\Events\CreateGrupoEvent;
 use Modulos\Integracao\Events\TurmaMapeadaEvent;
+use Modulos\Academico\Events\CreateMatriculaTurmaEvent;
+use Modulos\Academico\Events\CreateMatriculaDisciplinaEvent;
+use Modulos\Academico\Events\CreateMatriculaDisciplinaLoteEvent;
 
 /**
  * Class SincronizacaoListenerTest
@@ -108,6 +112,75 @@ class SincronizacaoListenerTest extends ModulosTestCase
         ]);
     }
 
+    private function mockUpDatabaseLote(int $qtdeMatriculas = 20)
+    {
+        // Cria a turma
+        $data = [
+            'trm_id' => random_int(50, 100),
+            'trm_ofc_id' => factory(Modulos\Academico\Models\OfertaCurso::class)->create()->ofc_id,
+            'trm_per_id' => factory(Modulos\Academico\Models\PeriodoLetivo::class)->create()->per_id,
+            'trm_nome' => "Turma de Teste",
+            'trm_integrada' => 1,
+            'trm_qtd_vagas' => 50
+        ];
+
+        $this->turma = factory(Modulos\Academico\Models\Turma::class)->create($data);
+
+        // Vincular com o ambiente
+        factory(\Modulos\Integracao\Models\AmbienteTurma::class)->create([
+            'atr_trm_id' => $this->turma->trm_id,
+            'atr_amb_id' => $this->ambiente->amb_id
+        ]);
+
+        // Mapeia a turma
+        $sincronizacaoListener = $this->app->make(\Modulos\Integracao\Listeners\SincronizacaoListener::class);
+        $turmaMapeadaListener = $this->app->make(\Modulos\Integracao\Listeners\TurmaMapeadaListener::class);
+        $createGroupListener = $this->app->make(\Modulos\Academico\Listeners\CreateGrupoListener::class);
+        $createMatriculaTurmaListener = $this->app->make(\Modulos\Academico\Listeners\CreateMatriculaTurmaListener::class);
+
+        // Eventos de turma
+        $turmaMapeadaEvent = new TurmaMapeadaEvent($this->turma);
+
+        $sincronizacaoListener->handle($turmaMapeadaEvent);
+        $turmaMapeadaListener->handle($turmaMapeadaEvent);
+
+        // Cria o grupo
+        $grupo = factory(\Modulos\Academico\Models\Grupo::class)->create([
+            'grp_trm_id' => $this->turma->trm_id,
+            'grp_pol_id' => factory(Modulos\Academico\Models\Polo::class)->create()->pol_id,
+            'grp_nome' => "Group A"
+        ]);
+
+        // Eventos de grupo
+        $createGroupEvent = new CreateGrupoEvent($grupo);
+
+        $sincronizacaoListener->handle($createGroupEvent);
+        $createGroupListener->handle($createGroupEvent);
+
+        // Cria a matricula no curso
+        $matriculaCurso = factory(\Modulos\Academico\Models\Matricula::class)->create([
+            'mat_trm_id' => $this->turma->trm_id,
+            'mat_grp_id' => $grupo->grp_id,
+        ]);
+
+        $createMatriculaTurmaEvent = new CreateMatriculaTurmaEvent($matriculaCurso);
+
+        // Eventos de Matricula no curso
+        $sincronizacaoListener->handle($createMatriculaTurmaEvent);
+        $createMatriculaTurmaListener->handle($createMatriculaTurmaEvent);
+
+        // Matricula disciplina
+        $matriculasDisciplinas = collect([]);
+
+        for ($i = 0; $i < $qtdeMatriculas; $i++) {
+            $matriculasDisciplinas[] = factory(\Modulos\Academico\Models\MatriculaOfertaDisciplina::class)->create([
+                'mof_mat_id' => $matriculaCurso->mat_id,
+            ]);
+        }
+
+        return $matriculasDisciplinas;
+    }
+
     public function testHandle()
     {
         $sincronizacaoListener = $this->app->make(\Modulos\Integracao\Listeners\SincronizacaoListener::class);
@@ -125,5 +198,36 @@ class SincronizacaoListenerTest extends ModulosTestCase
             'sym_data_envio' => null,
             'sym_extra' => $turmaMapeadaEvent->getExtra()
         ]);
+    }
+
+    public function testHandleMigracaoLote()
+    {
+        $sincronizacaoListener = $this->app->make(\Modulos\Integracao\Listeners\SincronizacaoListener::class);
+
+        $matriculas = $this->mockUpDatabaseLote(10);
+
+        \Modulos\Integracao\Models\Sincronizacao::truncate(); // Limpa eventos relacionados ao Mock
+
+        $this->assertEquals(0, \Modulos\Integracao\Models\Sincronizacao::all()->count());
+
+        $matriculaDisciplinaLoteEvent = new CreateMatriculaDisciplinaLoteEvent($matriculas);
+        $sincronizacaoListener->handle($matriculaDisciplinaLoteEvent);
+
+        $this->assertEquals(10, \Modulos\Integracao\Models\Sincronizacao::all()->count());
+
+        // Cria um evento de matricula com alguma das matriculas passadas.
+        // O objetivo eh checar se ha um log individual daquele registro na tabela de sincronizacao
+        $matriculaDisciplinaEvent = new CreateMatriculaDisciplinaEvent($matriculaDisciplinaLoteEvent->getItens()->random());
+
+        $this->assertDatabaseHas('int_sync_moodle', [
+            'sym_table' => $matriculaDisciplinaEvent->getData()->getTable(),
+            'sym_table_id' => $matriculaDisciplinaEvent->getData()->getKey(),
+            'sym_action' => $matriculaDisciplinaEvent->getAction(),
+            'sym_status' => 1,
+            'sym_mensagem' => null,
+            'sym_data_envio' => null,
+            'sym_extra' => $matriculaDisciplinaEvent->getExtra()
+        ]);
+
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/ce02749c9c7e41cdaefd89af3c60c2cb)](https://www.codacy.com/app/willianmanoaraujo/harpia?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=uemanet/harpia&amp;utm_campaign=Badge_Grade) [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/ce02749c9c7e41cdaefd89af3c60c2cb)](https://www.codacy.com/app/willianmanoaraujo/harpia?utm_source=github.com&utm_medium=referral&utm_content=uemanet/harpia&utm_campaign=Badge_Coverage)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/ce02749c9c7e41cdaefd89af3c60c2cb)](https://www.codacy.com/app/willianmanoaraujo/harpia?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=uemanet/harpia&amp;utm_campaign=Badge_Grade) [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/ce02749c9c7e41cdaefd89af3c60c2cb)](https://www.codacy.com/app/willianmanoaraujo/harpia?utm_source=github.com&utm_medium=referral&utm_content=uemanet/harpia&utm_campaign=Badge_Coverage) [![Build Status](https://travis-ci.org/uemanet/harpia.svg?branch=master)](https://travis-ci.org/uemanet/harpia)
 
 Harpia - UemaNet
 =======================


### PR DESCRIPTION
- Refatorada implementação de Matrícula em Lote para disciplina: É disparado um evento de Matrícula em Lote que irá migrar os dados para o ambiente virtual. Apesar do evento trabalhar com Matrícula em Lote, cada matrícula é logada individualmente na tabela de sincronização.

Obs.: Necessário que os ambientes tenham o plugin [moodle-local_integracao](https://github.com/uemanet/moodle-local_integracao) atualizado com o uemanet/moodle-local_integracao#2.