### PR TITLE
Regra de exceção de lançamento de tcc para cursos do nível Aperfeiçoamento

### DIFF
--- a/modulos/Academico/Repositories/MatriculaCursoRepository.php
+++ b/modulos/Academico/Repositories/MatriculaCursoRepository.php
@@ -429,7 +429,7 @@ class MatriculaCursoRepository extends BaseRepository
         }
 
         // A 4º e 5º regra nao se aplicam aos cursos tecnicos
-        if ($curso->crs_nvc_id != 2) {
+        if (!in_array($curso->crs_nvc_id, [2,7])) {
             // 4º Regra - Aprovação Tcc
             $aprovacao = $this->verifyIfAlunoAprovadoTcc($matricula);
             if (!$aprovacao) {


### PR DESCRIPTION
Ao tentar concluir a matricula de alunos de cursos do tipo Aperfeiçoamento, há uma exigência para lançamento de TCC. Como esse tipo de curso não necessita de TCC, ele foi incluído na regra de exceção de lançamento de TCC.