### PR TITLE
Regra de negócio de lançamento de aproveitamentos alterada e correção em migração de tutor para o AVA

### DIFF
--- a/modulos/Academico/Http/Controllers/TurmasController.php
+++ b/modulos/Academico/Http/Controllers/TurmasController.php
@@ -122,7 +122,7 @@ class TurmasController extends BaseController
 
         $curso = $oferta->curso->where('crs_id', $oferta->curso->crs_id)->pluck('crs_nome', 'crs_id');
 
-        $periodosletivos = $this->periodoletivoRepository->getPeriodosValidos($oferta->ofc_ano, date('Y'));
+        $periodosletivos = $this->periodoletivoRepository->getPeriodosValidos($oferta->ofc_ano, null);
 
         return view('Academico::turmas.create', compact('curso', 'periodosletivos', 'oferta'));
     }

--- a/modulos/Academico/Listeners/CreateVinculoTutorListener.php
+++ b/modulos/Academico/Listeners/CreateVinculoTutorListener.php
@@ -41,7 +41,7 @@ class CreateVinculoTutorListener
             $tutorGrupo = $event->getData();
             $tutor = $this->tutorRepository->find($tutorGrupo->ttg_tut_id);
             $grupo = $this->grupoRepository->find($tutorGrupo->ttg_grp_id);
-
+            
             // ambiente virtual vinculado à turma do grupo
             $ambiente = $this->ambienteVirtualRepository->getAmbienteByTurma($grupo->grp_trm_id);
 
@@ -59,8 +59,7 @@ class CreateVinculoTutorListener
                 $firstName = array_shift($name);
                 $lastName = implode(" ", $name);
 
-                $data['tutor']['ttg_tipo_tutoria'] = $this->tutorGrupoRepository
-                    ->getTipoTutoria($tutor->tut_id, $grupo->grp_id);
+                $data['tutor']['ttg_tipo_tutoria'] = $tutorGrupo->getOriginal('ttg_tipo_tutoria');
 
                 $data['tutor']['grp_id'] = $grupo->grp_id;
                 $data['tutor']['pes_id'] = $tutor->tut_pes_id;

--- a/modulos/Academico/Repositories/AproveitamentoEstudosRepository.php
+++ b/modulos/Academico/Repositories/AproveitamentoEstudosRepository.php
@@ -123,7 +123,7 @@ class AproveitamentoEstudosRepository extends BaseRepository
         $matriculaoferta = $this->model
             ->where('mof_mat_id', '=', $matriculaId)
             ->where('mof_ofd_id', '=', $ofertaId)
-            ->where('mof_status_matricula', '<>',  'cancelado')->get();
+            ->where('mof_situacao_matricula', '<>',  'cancelado')->get();
 
         if ($matriculaoferta->count()){
             return array("type" => "error", "message" => "Aluno já foi matriculado nessa disciplina");

--- a/modulos/Academico/Repositories/AproveitamentoEstudosRepository.php
+++ b/modulos/Academico/Repositories/AproveitamentoEstudosRepository.php
@@ -122,7 +122,8 @@ class AproveitamentoEstudosRepository extends BaseRepository
 
         $matriculaoferta = $this->model
             ->where('mof_mat_id', '=', $matriculaId)
-            ->where('mof_ofd_id', '=', $ofertaId)->get();
+            ->where('mof_ofd_id', '=', $ofertaId)
+            ->where('mof_status_matricula', '<>',  'cancelado')->get();
 
         if ($matriculaoferta->count()){
             return array("type" => "error", "message" => "Aluno já foi matriculado nessa disciplina");

--- a/modulos/Academico/Repositories/PeriodoLetivoRepository.php
+++ b/modulos/Academico/Repositories/PeriodoLetivoRepository.php
@@ -57,10 +57,9 @@ class PeriodoLetivoRepository extends BaseRepository
         return $result;
     }
 
-    public function getPeriodosValidos($ofc_ano, $periodo)
+    public function getPeriodosValidos($ofc_ano, $periodo = null)
     {
         $periodosvalidos = $this->model
-            ->where('per_inicio', '<=', date('Y-m-d'))
             ->where('per_fim', '>=', date('Y-m-d'))
             ->orderBy('per_inicio', 'ASC')
             ->pluck('per_nome', 'per_id')

--- a/modulos/Academico/Repositories/PeriodoLetivoRepository.php
+++ b/modulos/Academico/Repositories/PeriodoLetivoRepository.php
@@ -60,7 +60,7 @@ class PeriodoLetivoRepository extends BaseRepository
     public function getPeriodosValidos($ofc_ano, $periodo)
     {
         $periodosvalidos = $this->model
-            ->whereYear('per_inicio', '>=', $ofc_ano)
+            ->where('per_inicio', '<=', date('Y-m-d'))
             ->where('per_fim', '>=', date('Y-m-d'))
             ->orderBy('per_inicio', 'ASC')
             ->pluck('per_nome', 'per_id')

--- a/modulos/Academico/Repositories/TutorGrupoRepository.php
+++ b/modulos/Academico/Repositories/TutorGrupoRepository.php
@@ -52,15 +52,4 @@ class TutorGrupoRepository extends BaseRepository
 
         return $returnArray;
     }
-
-
-    public function getTipoTutoria($tutorId, $grupoId)
-    {
-        $result = $this->model
-            ->where('ttg_grp_id', '=', $grupoId)
-            ->where('ttg_tut_id', '=', $tutorId)
-            ->pluck('ttg_tipo_tutoria')->toArray();
-
-        return array_pop($result);
-    }
 }

--- a/modulos/Academico/tests/Repositories/PeriodoLetivoRepositoryTest.php
+++ b/modulos/Academico/tests/Repositories/PeriodoLetivoRepositoryTest.php
@@ -278,7 +278,7 @@ class PeriodoLetivoRepositoryTest extends ModulosTestCase
 
         $periodosLetivos[] = factory(PeriodoLetivo::class)->create([
             'per_inicio' => '04/06/' . $currentYear,
-            'per_fim' => '11/12/' . $currentYear
+            'per_fim' => '31/12/' . $currentYear
         ]);
 
         $nextYear = $currentYear + 1;
@@ -290,7 +290,7 @@ class PeriodoLetivoRepositoryTest extends ModulosTestCase
 
         $periodosLetivos[] = factory(PeriodoLetivo::class)->create([
             'per_inicio' => '04/06/' . $nextYear,
-            'per_fim' => '18/12/' . $nextYear
+            'per_fim' => '31/12/' . $nextYear
         ]);
 
         // Sao validos 4 periodos para o primeiro periodo letivo do ano corrente

--- a/modulos/Academico/tests/Repositories/TutorGrupoRepositoryTest.php
+++ b/modulos/Academico/tests/Repositories/TutorGrupoRepositoryTest.php
@@ -211,15 +211,6 @@ class TutorGrupoRepositoryTest extends ModulosTestCase
         $this->assertNotEmpty($response);
     }
 
-    public function testgetTipoTutoria()
-    {
-        $tutorgrupo = factory(\Modulos\Academico\Models\TutorGrupo::class)->create(['ttg_tipo_tutoria' => 'presencial']);
-        $response = $this->repo->getTipoTutoria($tutorgrupo->ttg_tut_id, $tutorgrupo->ttg_grp_id);
-
-        $this->assertEquals('Presencial', $response);
-        $this->assertNotEmpty($response);
-    }
-
     public function testpaginateRequestByGrupo()
     {
         $tutorgrupo = factory(\Modulos\Academico\Models\TutorGrupo::class)->create();


### PR DESCRIPTION
Regra de negócio de lançamento de aproveitamentos alterada para não barrar alunos com matrículas em disciplina com status cancelado

Closes #30 

Correção em migração de tutor para o AVA (tutores a distância e presenciais estavam sendo migrados com o papel de tutor a distância, sem importar o tipo de tutoria selecionado)