### PR TITLE
correção em bug de conclusão de curso

### DIFF
--- a/modulos/Academico/Repositories/MatriculaCursoRepository.php
+++ b/modulos/Academico/Repositories/MatriculaCursoRepository.php
@@ -623,8 +623,15 @@ class MatriculaCursoRepository extends BaseRepository
             ->first();
 
         if ($disciplinaTcc) {
+
             $matriculaOferta = $this->matriculaOfertaDisciplinaRepository->getMatriculasOfertasDisciplinasByMatricula($matricula->mat_id,
-                ['ofd_mdc_id' => $disciplinaTcc->mdc_id, 'ofd_trm_id' => $matricula->mat_trm_id])[0];
+                ['ofd_mdc_id' => $disciplinaTcc->mdc_id, 'ofd_trm_id' => $matricula->mat_trm_id]);
+
+            if(!$matriculaOferta){
+                return false;
+            }
+
+            $matriculaOferta = array_shift($matriculaOferta);
 
             return in_array($matriculaOferta->mof_situacao_matricula, ['aprovado_media', 'aprovado_final']);
         }


### PR DESCRIPTION
**Esse PR resolve o seguinte problema:**
No momento de concluir os alunos de um curso:
Caso a turma tenha uma disciplina do tipo TCC e algum aluno não estivesse matriculado nessa disciplina, ao invés de o aluno ser marcado como "Aluno não possui aprovação na disciplina de TCC" ou "Não possui aprovação em todas as disciplinas obrigatórias", aparecia um alerta de erro, pois existia uma variável que sempre esperava receber como retorno de uma função um array com um registro (caso o aluno se enquadre nesse caso a função retorna um array vazio).