### PR TITLE
Correcao resolucao

### DIFF
--- a/modulos/Academico/Views/historicodefinitivo/especializacao.blade.php
+++ b/modulos/Academico/Views/historicodefinitivo/especializacao.blade.php
@@ -202,7 +202,8 @@
         <td class="center"><strong>REGULAMENTAÇÃO</strong></td>
     </tr>
     <tr>
-        <td style="text-align: justify;">“O Curso está em conformidade com a Resolução n ° 01 CNE/CES de 08 de junho de 2007 e Normas dos cursos de Pós-Graduação “Lato Sensu” da Universidade Estadual do Maranhão aprovada pela Resolução N° {{$dados['curso']->crs_resolucao}}-{{$dados['curso']->crs_autorizacao}} de {{utf8_encode(strftime('%d de %B de %Y', strtotime($dados['curso']->crs_data_autorizacao)))}}”.</td>
+        <td style="text-align: justify;">“O Curso está em conformidade com a Resolução n ° 01 CNE/CES de 08 de junho de 2007 e Normas dos cursos de PósGraduação “Lato Sensu” da Universidade Estadual do Maranhão aprovada pela Resolução N° 1244/2017-CEPE/UEMA de 04 de
+            abril de 2017”.</td>
     </tr>
     </tbody>
 </table>

--- a/modulos/Academico/Views/historicodefinitivo/especializacao.blade.php
+++ b/modulos/Academico/Views/historicodefinitivo/especializacao.blade.php
@@ -21,7 +21,7 @@
         }
 
         .heightMin td{
-            height: 7em;
+            height: 5em;
             vertical-align: top;
         }
 
@@ -202,7 +202,7 @@
         <td class="center"><strong>REGULAMENTAÇÃO</strong></td>
     </tr>
     <tr>
-        <td style="text-align: justify;">“O Curso está em conformidade com a Resolução n ° 01 CNE/CES de 08 de junho de 2007 e Normas dos cursos de PósGraduação “Lato Sensu” da Universidade Estadual do Maranhão aprovada pela Resolução N° 1244/2017-CEPE/UEMA de 04 de
+        <td style="text-align: justify;">“O Curso está em conformidade com a Resolução n ° 01 CNE/CES de 08 de junho de 2007 e Normas dos cursos de Pós-Graduação “Lato Sensu” da Universidade Estadual do Maranhão aprovada pela Resolução N° 1244/2017-CEPE/UEMA de 04 de
             abril de 2017”.</td>
     </tr>
     </tbody>


### PR DESCRIPTION
Este PR faz algumas pequenas alterações nos históricos definitivos:

- O campo de resolução teve o seu texto alterado.
- O tamanho do espaço em branco que fica após a listagem das disciplinas foi diminuído (isso fazia com que a página do histórico quebrasse para duas páginas).