### PR TITLE
correção de bug ao gerar relatório XLS e remoção de obrigatoriedade em cadastro de módulos de uma matriz curricular

### DIFF
--- a/modulos/Academico/Database/Migrations/2019_11_21_192000_alter_field_mdo_qualificacao_modulos_matrizes.php
+++ b/modulos/Academico/Database/Migrations/2019_11_21_192000_alter_field_mdo_qualificacao_modulos_matrizes.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterFieldMdoQualificacaoModulosMatrizes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('acd_modulos_matrizes', function (Blueprint $table) {
+            $table->text('mdo_qualificacao')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('acd_modulos_matrizes', function (Blueprint $table) {
+            $table->string('mdo_qualificacao', 255)->change();
+        });
+    }
+}

--- a/modulos/Academico/Http/Controllers/RelatoriosMatriculasCursoController.php
+++ b/modulos/Academico/Http/Controllers/RelatoriosMatriculasCursoController.php
@@ -162,7 +162,7 @@ class RelatoriosMatriculasCursoController extends BaseController
 
         $turma = $this->turmaRepository->find($turmaId);
 
-        return Excel::download(new MatriculaReportExport(array('trm_id' => $turmaId, 'mat_situacao' => $situacao, 'pol_id' => $poloId), $matriculas, $curso, $turma), 'Relatório de alunos do curso: ' . $curso->crs_nome.'.xlsx');
+        return Excel::download(new MatriculaReportExport(array('trm_id' => $turmaId, 'mat_situacao' => $situacao, 'pol_id' => $poloId), $matriculas, $curso, $turma), 'Relatório de alunos do curso: ' . str_replace("/", "-", $curso->crs_nome).'.xlsx');
 
     }
 }

--- a/modulos/Academico/Http/Controllers/RelatoriosMatriculasDisciplinaController.php
+++ b/modulos/Academico/Http/Controllers/RelatoriosMatriculasDisciplinaController.php
@@ -183,7 +183,7 @@ class RelatoriosMatriculasDisciplinaController extends BaseController
 
         $turma = $this->turmaRepository->find($turmaId);
 
-        return Excel::download(new MatriculaDisciplinaReportExport(array('trm_id' => $turmaId, 'mat_situacao' => $situacao, 'pol_id' => $poloId), $alunos, $disciplina, $turma), 'Relatório de alunos da disciplina: ' . $disciplina[0].'.xlsx');
+        return Excel::download(new MatriculaDisciplinaReportExport(array('trm_id' => $turmaId, 'mat_situacao' => $situacao, 'pol_id' => $poloId), $alunos, $disciplina, $turma), 'Relatório de alunos da disciplina: ' . str_replace("/", "-", $disciplina[0]).'.xlsx');
 
     }
 }

--- a/modulos/Academico/Http/Requests/ModuloMatrizRequest.php
+++ b/modulos/Academico/Http/Requests/ModuloMatrizRequest.php
@@ -27,7 +27,7 @@ class ModuloMatrizRequest extends BaseRequest
             'mdo_mtc_id' => 'required',
             'mdo_nome' => 'required|min:3|max:45|',
             'mdo_descricao' => 'required|min:3|max:255',
-            'mdo_qualificacao' => 'required|min:3|max:255'
+            'mdo_qualificacao' => 'nullable|min:3|max:255'
         ];
 
         return $rules;

--- a/modulos/Academico/Views/modulosmatrizes/includes/formulario.blade.php
+++ b/modulos/Academico/Views/modulosmatrizes/includes/formulario.blade.php
@@ -48,7 +48,7 @@
 </div>
 <div class="row">
     <div class="form-group col-md-12 @if ($errors->has('mdo_qualificacao')) has-error @endif">
-        {!! Form::label('mdo_qualificacao', 'Qualificação*', ['class' => 'control-label']) !!}
+        {!! Form::label('mdo_qualificacao', 'Qualificação', ['class' => 'control-label']) !!}
         <div class="controls">
             {!! Form::text('mdo_qualificacao', old('mdo_qualificacao'), ['class' => 'form-control']) !!}
             @if ($errors->has('mdo_qualificacao')) <p class="help-block">{{ $errors->first('mdo_qualificacao') }}</p> @endif

--- a/modulos/Academico/routes.php
+++ b/modulos/Academico/routes.php
@@ -174,7 +174,7 @@ Route::group(['prefix' => 'academico', 'middleware' => ['auth']], function () {
 
     Route::group(['prefix' => 'aproveitamentoestudos'], function () {
         Route::get('/', '\Modulos\Academico\Http\Controllers\AproveitamentoEstudosController@getIndex')->name('academico.aproveitamentoestudos.index');
-        Route::get('/show/{idAluno}', '\Modulos\Academico\Http\Controllers\AproveitamentoEstudosController@getShow')->name('academico.aproveitamentoestudos.show');
+        Route::get('/show/{id}', '\Modulos\Academico\Http\Controllers\AproveitamentoEstudosController@getShow')->name('academico.aproveitamentoestudos.show');
         Route::post('/aproveitar/{ofertaId}/{matriculaId}', '\Modulos\Academico\Http\Controllers\AproveitamentoEstudosController@postAproveitarDisciplina')->name('academico.aproveitamentoestudos.aproveitardisciplina');
     });
 


### PR DESCRIPTION
Este PR tem alterações em duas funcionalidades:

- Ao gerar relatório de alunos matriculados por disciplina e alunos matriculados por curso no formato XLS, o nome do curso ou da disciplina é usado no nome do arquivo que está sendo exportado e caso esse nome tivesse o caractere "/"  uma excessão é disparada. Esse PR resolve esse problema.
- Retirada a obrigatoriedade do campo "qualificação" no cadastro de módulos da matriz curricular.