### PR TITLE
correção em geração de histórico definitivo e lançamento de TCC

### DIFF
--- a/modulos/Academico/Http/Controllers/LancamentosTccsController.php
+++ b/modulos/Academico/Http/Controllers/LancamentosTccsController.php
@@ -89,7 +89,7 @@ class LancamentosTccsController extends BaseController
         $turma = $this->turmaRepository->find($turmaId);
 
         $dados = $this->matriculacursoRepository->findDadosByTurmaId($turmaId);
-      
+
         if (!$turma) {
             flash()->error('Turma não existe!');
             return redirect()->back();
@@ -241,7 +241,7 @@ class LancamentosTccsController extends BaseController
 
         $disciplina = $this->lancamentotccRepository->findDisciplinaByTurma($lancamentoTcc->matriculaOferta->matriculaCurso->turma->trm_id);
 
-        return view('Academico::lancamentostccs.edit', compact('lancamentoTcc', 'turma', 'aluno', 'professores', 'disciplina', 'tiposdetcc', 'matricula', 'anexo'));
+        return view('Academico::lancamentostccs.edit', compact('lancamentoTcc', 'professores', 'disciplina', 'tiposdetcc', 'anexo'));
     }
 
     public function putEdit($lancamentotccId, LancamentoTccRequest $request)

--- a/modulos/Academico/Repositories/HistoricoDefinitivoRepository.php
+++ b/modulos/Academico/Repositories/HistoricoDefinitivoRepository.php
@@ -87,6 +87,7 @@ class HistoricoDefinitivoRepository
             })
             ->where('mdc_tipo_disciplina', '=', 'tcc')
             ->where('mof_mat_id', '=', $matricula->mat_id)
+            ->where('mof_situacao_matricula', '<>','cancelado')
             ->select('mof_id')
             ->first();
 


### PR DESCRIPTION
**Correção de um pequeno problema ao gerar histórico definitivo.**

Existe uma consulta de disciplina do tipo TCC que não englobava caso o aluno já tivesse uma matrícula cancelada, a alteração no código é bem auto-explicativa.

**correção em endpoint getEdit no controller de lançamento de Tcc**

Variáveis inexistentes na função compact