### PR TITLE
correção de bug ao gerar relatório de atas finais

### DIFF
--- a/modulos/Academico/Http/Controllers/RelatoriosAtasFinaisController.php
+++ b/modulos/Academico/Http/Controllers/RelatoriosAtasFinaisController.php
@@ -149,7 +149,7 @@ class RelatoriosAtasFinaisController extends BaseController
         $matrizTree = new MatrizCurricularTree($ofertaCurso->matriz);
 
         // Resultados das matriculas
-        $resultados = $this->resultadosFinaisRepository->getResultadosFinais($turma, $polo, $situacao);
+        $resultados = $this->resultadosFinaisRepository->getResultadosFinais($turma, $polo, $situacao ? null : '');
 
         $content = view('Academico::relatoriosatasfinais.relatorioatas', [
             'curso' => $curso,


### PR DESCRIPTION
Ao tentar gerar o relatório de atas finais, aparece o seguinte problema quando o status do aluno não é selecionado

![Captura de tela de 2020-03-09 17-51-19](https://user-images.githubusercontent.com/18468292/76256399-a38a7800-622e-11ea-9473-02315e935624.png)
 
Este PR resolve esse problema