### PR TITLE
fix(Academico): Corrige layout e margens do PDF do Histórico Definitivo

### DIFF
--- a/modulos/Academico/Http/Controllers/HistoricoDefinitivoController.php
+++ b/modulos/Academico/Http/Controllers/HistoricoDefinitivoController.php
@@ -39,11 +39,19 @@ class HistoricoDefinitivoController extends BaseController
         if (!empty($matriculas)) {
             $matr = $this->matriculaCursoRepository->find($matriculas['matriculas'][0])->first();
 
-            $mpdf = new Mpdf(['tempDir' => sys_get_temp_dir() . '/']);
+//            $mpdf = new Mpdf(['tempDir' => sys_get_temp_dir() . '/']);
+
+            $mpdf = new Mpdf([
+                'tempDir' => sys_get_temp_dir() . '/',
+                'margin_left' => 5,
+                'margin_right' => 5,
+                'margin_top' => 5,
+                'margin_bottom' => 5 // <-- Defina a margem inferior aqui (ex: 5mm)
+            ]);
 
             $cursoNome = $matr->turma->ofertacurso->curso->crs_nome;
             $mpdf->SetTitle('Histórico(s) Definitivo(s) - '. $cursoNome);
-            $mpdf->SetMargins(2, 2, 5);
+//            $mpdf->SetMargins(2, 2, 5);
 
             foreach ($matriculas['matriculas'] as $id) {
                 $matricula = $this->matriculaCursoRepository->find($id);

--- a/modulos/Academico/Views/historicodefinitivo/especializacao.blade.php
+++ b/modulos/Academico/Views/historicodefinitivo/especializacao.blade.php
@@ -169,14 +169,6 @@
             $creditosTotal += $disciplina->dis_creditos;
         @endphp
     @endforeach
-    <tr class="heightMin">
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-    </tr>
     </tbody>
 </table>
 <table>

--- a/modulos/Academico/Views/historicodefinitivo/graduacao.blade.php
+++ b/modulos/Academico/Views/historicodefinitivo/graduacao.blade.php
@@ -145,14 +145,6 @@
                     $creditosTotal += $disciplina->dis_creditos;
                 @endphp
             @endforeach
-            <tr class="heightMin">
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-            </tr>
         </tbody>
     </table>
     <table>


### PR DESCRIPTION
Este PR implementa duas melhorias na funcionalidade de geração de PDF para o Histórico Definitivo:

  1. Remoção de linha em branco: Foi corrigido um problema visual onde uma linha vazia era renderizada ao final da tabela de disciplinas. A causa era uma renderização incondicional de uma linha (<tr>) na view Blade, que foi ajustada para ser exibida apenas quando os dados pertinentes (como o TCC) existirem.
  3. Ajuste de Margens do PDF: As margens do documento foram reduzidas para otimizar o aproveitamento do espaço na página, resultando em um layout mais compacto e legível. A configuração foi centralizada no construtor da classe Mpdf para definir explicitamente as margens superior, direita, inferior e esquerda, garantindo consistência.