### PR TITLE
fix: corrige botão de atualizar situação da matrícula que não salvava

### DIFF
--- a/modulos/Academico/Views/alunos/includes/matriculas.blade.php
+++ b/modulos/Academico/Views/alunos/includes/matriculas.blade.php
@@ -309,49 +309,51 @@
                 event.preventDefault();
 
                 window.buttonGroup = $(this);
-                var modal = $(this).attr("data-content");
+                window.modalSituacao = $(this).attr("data-content");
 
-                $('#matricula-modal' + modal).modal();
+                $('#matricula-modal' + window.modalSituacao).modal();
+            });
 
-                $('.modalSave').on("click", function (event) {
-                    event.preventDefault();
+            $('.modalSave').on("click", function (event) {
+                event.preventDefault();
 
-                    var situacao = $('#situacao-select' + modal).val();
+                var modal = window.modalSituacao;
+                var situacao = $('#situacao-select' + modal).val();
 
-                    if (situacao.length === 0) {
-                        sweetAlert("Oops...", "Selecione uma opção", "error");
-                        return;
-                    }
+                if (situacao.length === 0) {
+                    sweetAlert("Oops...", "Selecione uma opção", "error");
+                    return;
+                }
 
-                    var confirmCallback = function (isConfirm) {
-                        if (isConfirm) {
-                            var matricula = window.buttonGroup.attr("value");
-                            var token = "{{ csrf_token() }}";
-                            var observacao = $('#observacao_situacao' + modal).val();
+                var confirmCallback = function (isConfirm) {
+                    if (isConfirm) {
+                        var matricula = window.buttonGroup.attr("value");
+                        var token = "{{ csrf_token() }}";
+                        var observacao = $('#observacao_situacao' + modal).val();
 
-                            data = {
-                                id: matricula,
-                                situacao: situacao,
-                                observacao: observacao,
-                                _token: token
-                            };
+                        var data = {
+                            id: matricula,
+                            situacao: situacao,
+                            observacao: observacao,
+                            _token: token
+                        };
 
-                            result = $.harpia.httppost('/academico/async/matricula/alterarsituacao', data);
+                        $.harpia.httppost('/academico/async/matricula/alterarsituacao', data).done(function () {
                             location.reload(true);
-                        }
-                    };
+                        });
+                    }
+                };
 
-                    swal({
-                        title: "Tem certeza que deseja alterar o status do aluno ?",
-                        type: "warning",
-                        showCancelButton: true,
-                        confirmButtonColor: "#DD6B55",
-                        confirmButtonText: "Sim, alterar status!",
-                        cancelButtonText: "Não, quero cancelar!",
-                        closeOnConfirm: true
-                    }, confirmCallback);
-                })
-            })
+                swal({
+                    title: "Tem certeza que deseja alterar o status do aluno ?",
+                    type: "warning",
+                    showCancelButton: true,
+                    confirmButtonColor: "#DD6B55",
+                    confirmButtonText: "Sim, alterar status!",
+                    cancelButtonText: "Não, quero cancelar!",
+                    closeOnConfirm: true
+                }, confirmCallback);
+            });
         });
 
         // Alteracao de polo e grupo


### PR DESCRIPTION
Resumo

- Bug: O botão "Atualizar Situação da Matrícula" aparentava funcionar (exibia o modal e a confirmação), mas a alteração nunca era salva em produção.
- Causa 1: location.reload(true) era chamado imediatamente após $.harpia.httppost(...), sem aguardar a conclusão da requisição AJAX — em produção, o reload cancelava a chamada antes de ela chegar ao servidor.
- Causa 2: O listener de clique no .modalSave era registrado dentro do listener de abertura do modal, acumulando handlers a cada vez que o modal era aberto e causando múltiplos disparos.

Correção

- Moveu o location.reload(true) para dentro do callback .done() do AJAX, garantindo que o reload só ocorra após a resposta do servidor.
- Extraiu o listener do .modalSave para fora do handler de abertura do modal, evitando o acúmulo de event listeners.
- Usa window.modalSituacao para compartilhar o ID do modal entre os dois handlers agora desacoplados.

Arquivos alterados

- modulos/Academico/Views/alunos/includes/matriculas.blade.php