### PR TITLE
feat: adiciona job de retry automático de sincronizações com o Moodle

### DIFF
--- a/app/Console/Commands/RetrySincronizacaoMoodleCommand.php
+++ b/app/Console/Commands/RetrySincronizacaoMoodleCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Harpia\Event\SincronizacaoFactory;
+use Illuminate\Console\Command;
+use Modulos\Integracao\Models\Sincronizacao;
+
+class RetrySincronizacaoMoodleCommand extends Command
+{
+    protected $signature = 'integracao:retry-sincronizacao
+                            {--limit=50 : Número máximo de registros processados por execução}';
+
+    protected $description = 'Retenta automaticamente sincronizações pendentes ou com falha no Moodle (máximo 3 tentativas)';
+
+    const MAX_TENTATIVAS = 3;
+
+    public function handle()
+    {
+        $limit = (int) $this->option('limit');
+
+        $pendentes = Sincronizacao::whereIn('sym_status', [1, 3])
+            ->where('sym_tentativas', '<', self::MAX_TENTATIVAS)
+            ->limit($limit)
+            ->get();
+
+        if ($pendentes->isEmpty()) {
+            $this->info('Nenhuma sincronização pendente para reprocessar.');
+            return;
+        }
+
+        $this->info("Reprocessando {$pendentes->count()} sincronização(ões)...");
+
+        $sucesso = 0;
+        $erro = 0;
+
+        foreach ($pendentes as $sincronizacao) {
+            try {
+                $sincronizacao->increment('sym_tentativas');
+
+                $evento = SincronizacaoFactory::factory($sincronizacao);
+                event($evento);
+
+                $sucesso++;
+            } catch (\Exception $e) {
+                $erro++;
+                $this->error("Falha ao reprocessar sym_id={$sincronizacao->sym_id}: {$e->getMessage()}");
+            }
+        }
+
+        $this->info("Concluído. Sucesso: {$sucesso} | Erros: {$erro}");
+
+        $esgotados = Sincronizacao::where('sym_status', 3)
+            ->where('sym_tentativas', '>=', self::MAX_TENTATIVAS)
+            ->count();
+
+        if ($esgotados > 0) {
+            $this->warn("{$esgotados} registro(s) atingiram o limite de tentativas e precisam de intervenção manual.");
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         // Commands\Inspire::class,
         Commands\ModulosMigrate::class,
         Commands\ModulosSeed::class,
+        Commands\RetrySincronizacaoMoodleCommand::class,
     ];
 
     /**
@@ -28,5 +29,9 @@ class Kernel extends ConsoleKernel
     {
         // $schedule->command('inspire')
         //          ->hourly();
+
+        $schedule->command('integracao:retry-sincronizacao')
+                 ->everyThirtyMinutes()
+                 ->withoutOverlapping();
     }
 }

--- a/modulos/Integracao/Database/Migrations/2026_06_09_000000_add_sym_tentativas_to_int_sync_moodle.php
+++ b/modulos/Integracao/Database/Migrations/2026_06_09_000000_add_sym_tentativas_to_int_sync_moodle.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSymTentativasToIntSyncMoodle extends Migration
+{
+    public function up()
+    {
+        Schema::table('int_sync_moodle', function (Blueprint $table) {
+            $table->integer('sym_tentativas')->default(0)->after('sym_version');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('int_sync_moodle', function (Blueprint $table) {
+            $table->dropColumn('sym_tentativas');
+        });
+    }
+}

--- a/modulos/Integracao/Models/Sincronizacao.php
+++ b/modulos/Integracao/Models/Sincronizacao.php
@@ -18,7 +18,8 @@ class Sincronizacao extends BaseModel
         'sym_mensagem',
         'sym_data_envio',
         'sym_extra',
-        'sym_version'
+        'sym_version',
+        'sym_tentativas'
     ];
 
     protected $searchable = [


### PR DESCRIPTION
Cria comando artisan `integracao:retry-sincronizacao` que reprocessa registros com status pendente (1) ou falhou (3) na tabela int_sync_moodle, respeitando limite de 3 tentativas por registro. Agendado a cada 30 minutos via scheduler do Laravel.