### PR TITLE
fix: corrige mat_id 0 na sincronização de situação da matrícula (v2)

### DIFF
--- a/modulos/Academico/Listeners/UpdateSituacaoMatriculaV2Listener.php
+++ b/modulos/Academico/Listeners/UpdateSituacaoMatriculaV2Listener.php
@@ -48,7 +48,7 @@ class UpdateSituacaoMatriculaV2Listener
 
                 $param['data']['student']['trm_id'] = (int)$matriculaTurma->mat_trm_id;
                 $param['data']['student']['pes_id'] = (int)$matriculaTurma->aluno->alu_pes_id;
-                $param['data']['student']['mat_id'] = (int)$matriculaTurma->id;
+                $param['data']['student']['mat_id'] = (int)$matriculaTurma->mat_id;
                 $param['data']['student']['new_status'] = $matriculaTurma->mat_situacao;
 
                 $response = Moodle::send($param);


### PR DESCRIPTION
## Resumo
- Corrige `UpdateSituacaoMatriculaV2Listener` que enviava `mat_id: 0` ao Moodle ao atualizar a situação da matrícula (ex: desistente), pois usava `$matriculaTurma->id` (atributo inexistente) em vez de `$matriculaTurma->mat_id` (chave primária real do model `Matricula`).
- Isso fazia o Moodle rejeitar a atualização com a mensagem "Esta matrícula não está vinculada com o ambiente virtual", mantendo o aluno com status desatualizado (ex: ativo no AVA mesmo após ser marcado como desistente no Harpia).

## Causa raiz
Identificado ao investigar chamado em que duas alunas foram marcadas como "desistente" no Harpia, mas permaneceram ativas no AVA. O log de sincronização (`int_sync_moodle`) confirmava o erro com `mat_id: 0`.

## Test plan
- [ ] Alterar a situação de uma matrícula vinculada a turma com integração v2 e confirmar no log `int_sync_moodle` que o `mat_id` enviado agora é o correto (não mais 0)
- [ ] Confirmar que a situação é refletida no AVA

🤖 Generated with [Claude Code](https://claude.com/claude-code)